### PR TITLE
Add new plugin deprecation rules

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -151,6 +151,9 @@ var ruleSet = []Rule{
 	NewRule("7.1.6", SeverityHigh, "Avoid using deprecated plugin static-filesystem. Please visit https://www.krakend.io/docs/enterprise/endpoints/serve-static-content/#upgrading-from-the-old-plugin-before-v24 to upgrade to the new static-filesystem.", hasDeprecatedClientPlugin("static-filesystem")),
 	NewRule("7.1.7", SeverityHigh, "Avoid using deprecated plugin no-redirect. Please visit https://www.krakend.io/docs/enterprise/backends/client-redirect/#migration-from-old-plugin to upgrade to the new options.", hasDeprecatedClientPlugin("no-redirect")),
 
+	NewRule("7.1.8", SeverityHigh, "Avoid using deprecated plugin content-replacer. Please visit https://www.krakend.io/docs/enterprise/endpoints/content-replacer/#migration-from-old-plugin to upgrade to the new options.", hasDeprecatedReqRespPlugin("content-replacer")),
+	NewRule("7.1.9", SeverityHigh, "Avoid using deprecated plugin response-schema-validator. Please visit https://www.krakend.io/docs/enterprise/endpoints/response-schema-validator/#migration-from-old-plugin to upgrade to the new options.", hasDeprecatedReqRespPlugin("response-schema-validator")),
+
 	// 7.2 Component Deprecations
 	NewRule("7.2.1", SeverityHigh, "Avoid using deprecated component telemetry/ganalytics. Please visit https://www.krakend.io/docs/telemetry/opentelemetry/ to upgrade to OpenTelemetry", hasDeprecatedGanalytics),
 	NewRule("7.2.2", SeverityHigh, "Avoid using deprecated component telemetry/instana. Please visit https://www.krakend.io/docs/telemetry/opentelemetry/ to upgrade to OpenTelemetry", hasDeprecatedInstana),

--- a/rules.go
+++ b/rules.go
@@ -14,6 +14,7 @@ import (
 	ratelimitProxy "github.com/krakendio/krakend-ratelimit/v3/proxy"
 	ratelimit "github.com/krakendio/krakend-ratelimit/v3/router"
 	"github.com/luraproject/lura/v2/proxy"
+	"github.com/luraproject/lura/v2/proxy/plugin"
 	router "github.com/luraproject/lura/v2/router/gin"
 	client "github.com/luraproject/lura/v2/transport/http/client/plugin"
 	server "github.com/luraproject/lura/v2/transport/http/server/plugin"
@@ -71,6 +72,25 @@ func hasDeprecatedClientPlugin(pluginName string) func(s *Service) bool {
 			comp, ok := ep.Components[client.Namespace]
 			if ok && len(comp) > 0 && comp[0] == compID {
 				return true
+			}
+		}
+		return false
+	}
+}
+
+func hasDeprecatedReqRespPlugin(pluginName string) func(s *Service) bool {
+	return func(s *Service) bool {
+		id := parseRespReqPlugin(pluginName)
+		for _, ep := range s.Endpoints {
+			comp, ok := ep.Components[plugin.Namespace]
+			if ok && hasBit(comp[0], id) {
+				return true
+			}
+			for _, b := range ep.Backends {
+				comp, ok := b.Components[plugin.Namespace]
+				if ok && hasBit(comp[0], id) {
+					return true
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
Adding new plugin deprecation rules

### 7.1.8
Deprecation error for `content-replacer` req-resp plugin

### 7.1.9
Deprecation error for `response-schema-validator` req-resp plugin