### PR TITLE
Upgrade workflows go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.24"
+        go-version: "1.25"
 
     - name: Test
       run: go test -cover -race ./...


### PR DESCRIPTION
This PR should group all other PR's which deprecates components in the 3.0 version.